### PR TITLE
VUQA-5373: Update the implicit permissions mapping and update the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,4 +53,4 @@ jobs:
           push: true
           tags: ghcr.io/vunetsystems/keycloak:${{ env.TAG_NAME }}
           build-args: |
-            KEYCLOAK_VERSION=${{ env.SEMVER }}
+            KEYCLOAK_VERSION=${{ env.TAG_NAME }}

--- a/quarkus/container/vunet/scripts/policy/evaluate-privileges.js
+++ b/quarkus/container/vunet/scripts/policy/evaluate-privileges.js
@@ -48,6 +48,8 @@ var implicitReverseMap = [
   { key: 'insights:write', value: 'insights:modifySystemResources' },
   { key: 'preferences:read', value: 'alerts:read' },
   { key: 'preferences:read', value: 'alerts:write' },
+  { key: 'preferences:read', value: 'events:read' },
+  { key: 'preferences:read', value: 'events:write' },
   { key: 'preferences:read', value: 'reports:read' },
   { key: 'preferences:read', value: 'reports:write' },
   { key: 'users:read', value: 'events:write' },


### PR DESCRIPTION
## Description of Changes

### VUQA-5373
Please see [linked PR](https://github.com/vunetsystems/vu_auth_provider/pull/238) for more details

### Changes to the `release` workflow
The workflow was setting the value of the `KEYCLOAK_VERSION` build argument incorrectly, which resulted in the Dockerfile always trying to download the first tar of a keycloak release, ignore all the subsequent releases (which had the `-r*` suffix)

## Linked Issues
- [VUQA-5373](https://vunetsystems.atlassian.net/browse/VUQA-5373)

## Design Document
NA

## Requirements Document
NA

## Impact Analysis
See [linked PR](https://github.com/vunetsystems/vu_auth_provider/pull/238)

## Any Similar Instances Found
NA

## Root Cause Analysis 
NA

## Files Changed
_List all major files changed along with a brief description of what was modified._
- `quarkus/container/vunet/scripts/policy/evaluate-privileges.js`: Updated `implicitReverseMap` in the permissions evaluator policy script

## Tests Conducted
See [linked PR](https://github.com/vunetsystems/vu_auth_provider/pull/238)

## Migration Steps (if applicable)
NA

## Rollback Instructions (if applicable)
NA

## Additional Context
NA

## Checklist
- [x] I have reviewed my code for errors and potential refactoring.
- [x] I have updated the documentation as necessary.
- [x] I have added tests to cover my changes.
- [x] This PR is ready for review.


[VUQA-5373]: https://vunetsystems.atlassian.net/browse/VUQA-5373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ