### PR TITLE
CCBD-2190: Password encryption in Keycloak should be enabled by default

### DIFF
--- a/quarkus/container/vunet/provisioning/realm.json
+++ b/quarkus/container/vunet/provisioning/realm.json
@@ -2819,7 +2819,7 @@
       "builtIn": true,
       "authenticationExecutions": [
         {
-          "authenticator": "auth-username-password-form",
+          "authenticator": "custom-username-password-form",
           "authenticatorFlow": false,
           "requirement": "REQUIRED",
           "priority": 10,


### PR DESCRIPTION
## Description of Changes
We have changed the default username and password form to custom vunet username and password form in browser flow. 
Custom form supports password encryption and offline captcha by default.

## Linked Issues
- [CCBD-2190](https://vunetsystems.atlassian.net/browse/CCBD-2190): *Password encryption in Keycloak should be enabled by default* 
Linked Issue:
https://vunetsystems.atlassian.net/browse/CCBD-2093
https://vunetsystems.atlassian.net/browse/CCBD-1893

## Design Document

## Requirements Document

## Impact Analysis
We have released our custom username and password form with various functionalities mentioned below:
1. Password encryption as default behaviour: Password is sent from UI to keycloak backend in encrypted format.
2. Offline catch: We have offline captcha feature(Can be enabled or disabled) in the form configuration..

## Files Changed
realm.json: We have added our custom username and password as authenticator in browser flow by default.

## Tests Conducted

<img width="1800" alt="Screenshot 2025-04-23 at 3 20 49 PM" src="https://github.com/user-attachments/assets/99ab1db5-e340-450b-9beb-2e0d8f9a7a55" />

<img width="1798" alt="Screenshot 2025-04-23 at 3 20 58 PM" src="https://github.com/user-attachments/assets/9850639b-b892-4b19-9ab3-045fdc49a65c" />

Flow Video:

Video Link: https://drive.google.com/file/d/1Ai6JnSASPocVI6NGU3G_c4ijsFf7PcaW/view?usp=sharing


## Additional Context

## Checklist


[CCBD-2190]: https://vunetsystems.atlassian.net/browse/CCBD-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ