### PR TITLE
VUQA-5390: Login : Resetting password for the LDAP user should not be allowed from Login Page.

### DIFF
--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -116,7 +116,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         if (user != null && user.getFederationLink() != null) {
             event.error(Errors.RESET_CREDENTIAL_DISABLED);
             Response challenge = context.form()
-                    .addError(new FormMessage(Validation.FIELD_USERNAME, Messages.RESET_CREDENTIAL_NOT_ALLOWED))
+                    .addError(new FormMessage(Validation.FIELD_USERNAME, Messages.RESET_CREDENTIAL_NOT_ALLOWED_FOR_FEDERATED_USER))
                     .createPasswordReset();
             context.failureChallenge(AuthenticationFlowError.ACCESS_DENIED, challenge);
             return;

--- a/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
+++ b/services/src/main/java/org/keycloak/authentication/authenticators/resetcred/ResetCredentialChooseUser.java
@@ -104,7 +104,7 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         }
 
         username = username.trim();
-        
+
         RealmModel realm = context.getRealm();
         UserModel user = context.getSession().users().getUserByUsername(realm, username);
         if (user == null && realm.isLoginWithEmailAllowed() && username.contains("@")) {
@@ -112,6 +112,15 @@ public class ResetCredentialChooseUser implements Authenticator, AuthenticatorFa
         }
 
         context.getAuthenticationSession().setAuthNote(AbstractUsernameFormAuthenticator.ATTEMPTED_USERNAME, username);
+
+        if (user != null && user.getFederationLink() != null) {
+            event.error(Errors.RESET_CREDENTIAL_DISABLED);
+            Response challenge = context.form()
+                    .addError(new FormMessage(Validation.FIELD_USERNAME, Messages.RESET_CREDENTIAL_NOT_ALLOWED))
+                    .createPasswordReset();
+            context.failureChallenge(AuthenticationFlowError.ACCESS_DENIED, challenge);
+            return;
+        }
 
         // we don't want people guessing usernames, so if there is a problem, just continue, but don't set the user
         // a null user will notify further executions, that this was a failure.

--- a/services/src/main/java/org/keycloak/services/messages/Messages.java
+++ b/services/src/main/java/org/keycloak/services/messages/Messages.java
@@ -156,6 +156,7 @@ public class Messages {
 
     public static final String REGISTRATION_NOT_ALLOWED = "registrationNotAllowedMessage";
     public static final String RESET_CREDENTIAL_NOT_ALLOWED = "resetCredentialNotAllowedMessage";
+    public static final String RESET_CREDENTIAL_NOT_ALLOWED_FOR_FEDERATED_USER = "resetCredentialNotAllowedforFederatedUserMessage";
 
     public static final String PERMISSION_NOT_APPROVED = "permissionNotApprovedMessage";
 

--- a/themes/src/main/resources/theme/base/login/messages/messages_en.properties
+++ b/themes/src/main/resources/theme/base/login/messages/messages_en.properties
@@ -336,6 +336,7 @@ unsupportedNameIdFormatMessage=Unsupported NameIDFormat
 invalidRequesterMessage=Invalid requester
 registrationNotAllowedMessage=Registration not allowed
 resetCredentialNotAllowedMessage=Reset Credential not allowed
+resetCredentialNotAllowedforFederatedUserMessage=Unable to reset account credentials. Contact admin for support.
 
 permissionNotApprovedMessage=Permission not approved.
 noRelayStateInResponseMessage=No relay state in response from identity provider.


### PR DESCRIPTION
## Description of Changes
We have disable to reset password for LDAP/Active Directory user.

## Linked Issues
- [VUQA-5390](https://vunetsystems.atlassian.net/browse/VUQA-5390): *[Login : Resetting password for the LDAP user should not be allowed from Login Page.]*  
 

## Design Document


## Requirements Document


## Impact Analysis
Now reset password feature will be disable by default for LDAP/Active Directory user.

## Any Similar Instances Found

## Root Cause Analysis 
Reset password feature was enabled by default for all the user in keycloak. If Sync method is set to writable in keycloak LDAP integration, password was getting updated in LDAP server. 

We have disable all the ldap user from resetting password irrespective of Sync method.

## Files Changed
ResetCredentialChooseUser.java: Once we get user from getUserbyusername or getUserbyEmail, We pull the info of user federation's link to check if it is federated user(Ldap User). Then we reject the password update.

## Tests Conducted

<img width="1781" alt="Screenshot 2025-05-05 at 6 14 43 PM" src="https://github.com/user-attachments/assets/1f8733d6-87db-4543-83e4-8d4efeabff5c" />

https://github.com/user-attachments/assets/f932bd91-3c57-4fd8-b416-fe843caefc82

## Additional Context

## Checklist


[VUQA-5390]: https://vunetsystems.atlassian.net/browse/VUQA-5390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ