### PR TITLE
VUQA-5607: Revert aria-label attribute to fix the login error

### DIFF
--- a/quarkus/container/vunet/theme/vunet/login/login.ftl
+++ b/quarkus/container/vunet/theme/vunet/login/login.ftl
@@ -65,7 +65,6 @@ displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled
           disabled=usernameEditDisabled??
           invalid=messagesPerField.existsError("username", "password")
           placeholder=usernameLabel
-          aria-label=usernameLabel
           message=kcSanitize(messagesPerField.getFirstError("username", "password"))
           name="username"
           type="text"
@@ -74,7 +73,6 @@ displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled
         <@input.kw
           invalid=messagesPerField.existsError("username", "password")
           placeholder=msg("password")
-          aria-label=msg("password")
           name="password"
           type="password"
         />


### PR DESCRIPTION
## Description of Changes
- **Bug Fixes**: input macro doesn't support hyphen in attribute names. Reverting aria-label attribute which was added in the earlier PR to fix the issue.

## Linked Issues
- [VUQA-5607](https://vunetsystems.atlassian.net/browse/VUQA-5607)

## Design Document
-

## Requirements Document
-

## Impact Analysis
-

## Any Similar Instances Found
-

## Root Cause Analysis 
-

## Files Changed
-

## Tests Conducted
-

## Migration Steps (if applicable)
-

## Additional Context
-

## Checklist
- [ ] I have reviewed my code for errors and potential refactoring.
- [ ] I have updated the documentation as necessary.
- [ ] I have added tests to cover my changes.
- [ ] This PR is ready for review.


[VUQA-5607]: https://vunetsystems.atlassian.net/browse/VUQA-5607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ