### PR TITLE
CCBD-4199: Download marauder release asset in CI before Docker build                                                                                                

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -451,14 +451,6 @@ jobs:
 
       - name: Resolve Marauder version
         run: |
-          BRANCH_TYPE='${{ needs.branch-context.outputs.branch-type }}'
-          if [[ "$BRANCH_TYPE" == "feature" ]]; then
-            echo "MARAUDER_VERSION=none" >> $GITHUB_ENV
-            echo "MARAUDER_TARBALL=none" >> $GITHUB_ENV
-            echo "Skipping Marauder resolution for feature branch build"
-            exit 0
-          fi
-
           if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
             REQUESTED_MARAUDER_TAG="${{ github.event.client_payload.release_tag }}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.marauder_tag }}" ]]; then
@@ -468,32 +460,53 @@ jobs:
           fi
 
           if [[ -n "$REQUESTED_MARAUDER_TAG" ]]; then
-            MARAUDER_VERSION="$(
+            RELEASE_JSON="$(
               curl -fsSL \
                 -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
                 -H "Accept: application/vnd.github+json" \
                 "https://api.github.com/repos/vunetsystems/marauder/releases/tags/${REQUESTED_MARAUDER_TAG}" \
-              | jq -r '.tag_name'
             )"
           else
-            MARAUDER_VERSION="$(
+            RELEASE_JSON="$(
               curl -fsSL \
                 -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
                 -H "Accept: application/vnd.github+json" \
                 https://api.github.com/repos/vunetsystems/marauder/releases/latest \
-              | jq -r '.tag_name'
             )"
           fi
+
+          MARAUDER_VERSION="$(printf '%s' "$RELEASE_JSON" | jq -r '.tag_name')"
+          MARAUDER_TARBALL="$(printf '%s' "$RELEASE_JSON" | jq -r '.assets[] | select(.name | startswith("marauder-plugins-") and endswith(".tar.gz")) | .name' | head -n1)"
+          MARAUDER_ASSET_ID="$(printf '%s' "$RELEASE_JSON" | jq -r --arg name "$MARAUDER_TARBALL" '.assets[] | select(.name == $name) | .id' | head -n1)"
 
           if [ -z "$MARAUDER_VERSION" ] || [ "$MARAUDER_VERSION" == "null" ]; then
             echo "ERROR: Could not resolve Marauder version."
             exit 1
           fi
 
-          MARAUDER_TARBALL="marauder-plugins-${MARAUDER_VERSION}.tar.gz"
+          if [ -z "$MARAUDER_TARBALL" ] || [ "$MARAUDER_TARBALL" == "null" ]; then
+            echo "ERROR: Could not resolve Marauder tarball asset for release ${MARAUDER_VERSION}."
+            exit 1
+          fi
+
+          if [ -z "$MARAUDER_ASSET_ID" ] || [ "$MARAUDER_ASSET_ID" == "null" ]; then
+            echo "ERROR: Could not resolve Marauder asset id for ${MARAUDER_TARBALL}."
+            exit 1
+          fi
 
           echo "MARAUDER_VERSION=${MARAUDER_VERSION}" >> $GITHUB_ENV
           echo "MARAUDER_TARBALL=${MARAUDER_TARBALL}" >> $GITHUB_ENV
+          echo "MARAUDER_ASSET_ID=${MARAUDER_ASSET_ID}" >> $GITHUB_ENV
+
+      - name: Download Marauder release asset
+        run: |
+          curl -fsSL \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
+            -H "Accept: application/octet-stream" \
+            "https://api.github.com/repos/vunetsystems/marauder/releases/assets/${MARAUDER_ASSET_ID}" \
+            -o quarkus/container/marauder-plugins.tar.gz
+
+          test -s quarkus/container/marauder-plugins.tar.gz
 
       - name: Compute image tag
         id: tags

--- a/quarkus/container/Dockerfile
+++ b/quarkus/container/Dockerfile
@@ -22,7 +22,8 @@ RUN bash ./build.sh
 
 ARG MARAUDER_VERSION
 ARG MARAUDER_TARBALL
-ARG MARAUDER_REPO=https://github.com/vunetsystems/marauder/releases/download
+
+COPY marauder-plugins.tar.gz /tmp/marauder-plugins.tar.gz
 
 RUN set -euo pipefail && \
     if [ -z "$MARAUDER_VERSION" ] || [ "$MARAUDER_VERSION" == "null" ]; then \
@@ -34,9 +35,11 @@ RUN set -euo pipefail && \
       exit 1; \
     fi && \
     mkdir -p /vunet/plugins && \
-    echo "Downloading: ${MARAUDER_REPO}/${MARAUDER_VERSION}/${MARAUDER_TARBALL}" && \
-    curl -fsSL "${MARAUDER_REPO}/${MARAUDER_VERSION}/${MARAUDER_TARBALL}" \
-         -o /tmp/marauder-plugins.tar.gz && \
+    if [ ! -f /tmp/marauder-plugins.tar.gz ]; then \
+      echo "ERROR: /tmp/marauder-plugins.tar.gz is missing from the Docker context"; \
+      exit 1; \
+    fi && \
+    echo "Extracting bundled Marauder asset: ${MARAUDER_TARBALL}" && \
     tar -xzf /tmp/marauder-plugins.tar.gz -C /vunet/plugins && \
     rm /tmp/marauder-plugins.tar.gz && \
     echo "=== Extracted Marauder plugins ===" && \


### PR DESCRIPTION
## Description of Changes
Updated the Washington CI pipeline and Dockerfile to fix the CI pipeline failure. Washington moves the Marauder tarball download from inside the Docker build to a dedicated CI step that runs before the build. The downloaded asset is then COPY-ed directly into the image, eliminating network dependency during the Docker build itself.


## Linked Issues
[CCBD-4199](https://vunetsystems.atlassian.net/browse/CCBD-4199) : [CI Pipeline and Dockerfile update for Marauder plugin integration]

## Design Document

## Requirements Document

## Impact Analysis


## Any Similar Instances Found


## Root Cause Analysis 

## Files Changed
- .github/workflows/release.yml: Removed feature-branch skip; refactored Marauder version/tarball/asset-ID resolution into a single API call; added explicit validation for each extracted value, added a new "Download Marauder release asset" step that fetches the tarball into the Docker build context before the image build runs.
- quarkus/container/Dockerfile: Removed MARAUDER_REPO build-arg and in-container curl download; replaced with COPY marauder-plugins.tar.gz /tmp/ and a  pre-extraction existence check.    

## Tests Conducted

## Migration Steps 


## Additional Context
This is part of the broader CI automation initiative connecting Marauder and Washington pipelines.

## Checklist

[CCBD-4199]: https://vunetsystems.atlassian.net/browse/CCBD-4199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ