### PR TITLE
CCBD-4198: Fix release CI 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -673,6 +673,7 @@ jobs:
           git diff --quiet || {
             git add .
             git commit -m "chore: update keycloak image tag to $TAG"
+            git pull --rebase origin "$(git branch --show-current)" || true
             git push origin "$(git branch --show-current)"
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
               exit 0
             fi
             echo "branch-type=release"        >> $GITHUB_OUTPUT
-            echo "should-build=false"         >> $GITHUB_OUTPUT
+            echo "should-build=true"          >> $GITHUB_OUTPUT
             echo "run-release-retag=true"     >> $GITHUB_OUTPUT
-            echo "run-versioning=false"       >> $GITHUB_OUTPUT
-            echo "run-release=false"          >> $GITHUB_OUTPUT
+            echo "run-versioning=true"        >> $GITHUB_OUTPUT
+            echo "run-release=true"           >> $GITHUB_OUTPUT
             echo "ref-name=$REF"              >> $GITHUB_OUTPUT
             RELEASE_SLUG=$(echo "$REF" | sed 's|release/||' | sed 's|[^a-zA-Z0-9]|-|g')
             echo "concurrency-group=washington-release-${RELEASE_SLUG}" >> $GITHUB_OUTPUT
@@ -317,12 +317,13 @@ jobs:
   # ---------------------------------------------------------------------------
   versioning:
     name: Versioning
-    needs: [branch-context, gate]
+    needs: [branch-context, gate, release-retag]
     if: |
       always() &&
       needs.branch-context.outputs.should-build == 'true' &&
       needs.branch-context.outputs.is-test-run == 'false' &&
-      needs.gate.result == 'success'
+      needs.gate.result == 'success' &&
+      !contains(fromJSON('["failure", "cancelled"]'), needs.release-retag.result)
     runs-on: ubuntu-latest
     outputs:
       # Track A — Keycloak version
@@ -340,7 +341,8 @@ jobs:
       - name: Checkout Washington
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.branch-context.outputs.checkout-ref }}
+          ref: ${{ needs.branch-context.outputs.ref-name }}
+          fetch-depth: 0
 
       - name: Extract Jira Ticket
         id: extract-jira

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,13 +274,24 @@ jobs:
         env:
           VERSION: ${{ steps.rel.outputs.version }}
 
-      - name: Commit and push .version to release branch
+      - name: Update pom.xml version for release branch
+        env:
+          VERSION: ${{ steps.rel.outputs.version }}
+        run: |
+          if [ -x "./set-version.sh" ]; then
+            ./set-version.sh "${VERSION}"
+            echo "Updated pom.xml to ${VERSION}"
+          else
+            echo "set-version.sh not found; skipping pom.xml update"
+          fi
+
+      - name: Commit and push version changes to release branch
         env:
           VERSION: ${{ steps.rel.outputs.version }}
         run: |
           git config user.name "vunet-new-ci-cd-bot[bot]"
           git config user.email "vunet-new-ci-cd-bot@users.noreply.github.com"
-          git add resources/.version
+          git add -A
           git diff --cached --quiet || {
             git commit -m "chore: bump washington version to v${VERSION} [skip ci]"
             git push origin HEAD:${{ needs.branch-context.outputs.ref-name }}


### PR DESCRIPTION
Fixes washington CI to build, push image, and update hanoi on release branch creation with correct version.           
                                                                                                                        
  Description of Changes                                                                                                
                                                                                                                        
  - should-build=true on create event for release branches (was false — only seeded version, no build)                  
  - run-versioning=true and run-release=true on create event                                                            
  - release-retag now runs set-version.sh to update pom.xml to release version on the release branch (was only updating
  resources/.version, so versioning read develop's pom.xml version 999.0.0 instead of 16.0.0)                           
  - versioning now needs: release-retag — waits for pom.xml update before reading version
  - versioning checkout uses ref-name (latest branch HEAD after seed) instead of github.sha                             
  - Added git pull --rebase before hanoi push to prevent race condition                                                 
  - git add -A in release-retag commit to include both resources/.version and pom.xml changes 