### PR TITLE
CCBD-4198: Fixed keycloak version calculation and  commit-bumps race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -627,8 +627,7 @@ jobs:
       needs.branch-context.outputs.should-build == 'true' &&
       needs.branch-context.outputs.is-test-run == 'false' &&
       needs.gate.result == 'success' &&
-      needs.build.result == 'success' &&
-      github.event_name != 'push'
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     env:
       HANOI_TARGET: ${{ needs.branch-context.outputs.hanoi-target }}
@@ -716,7 +715,7 @@ jobs:
       needs.branch-context.outputs.branch-type == 'release' &&
       needs.versioning.outputs.keycloak-version != '' &&
       needs.build.result == 'success' &&
-      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped') &&
+      needs.helm-update.result == 'success' &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
@@ -799,7 +798,7 @@ jobs:
       needs.branch-context.outputs.is-test-run == 'false' &&
       needs.gate.result == 'success' &&
       needs.build.result == 'success' &&
-      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped')
+      needs.helm-update.result == 'success'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -733,8 +733,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          ref: ${{ needs.branch-context.outputs.checkout-ref }}
+          ref: ${{ needs.branch-context.outputs.ref-name }}
           fetch-depth: 0
+      - name: Pull latest changes
+        run: |
+            git config user.name "vunet-new-ci-cd-bot[bot]"
+            git config user.email "vunet-new-ci-cd-bot@users.noreply.github.com"
+            git pull origin ${{ needs.branch-context.outputs.ref-name }}
 
       - name: Update pom.xml with new Keycloak version
         run: |
@@ -774,15 +779,12 @@ jobs:
 
       - name: Commit and push
         run: |
-          git config user.name "vunet-new-ci-cd-bot[bot]"
-          git config user.email "vunet-new-ci-cd-bot@users.noreply.github.com"
           git add -A
           if git diff --cached --quiet; then
-            echo "No changes detected, skipping commit/push."
-            exit 0
+           echo "No changes detected, skipping commit/push."
+           exit 0
           fi
           git commit -m "chore: bump washington version to v${{ needs.versioning.outputs.platform-version }} [skip ci]"
-          git pull --rebase origin ${{ needs.branch-context.outputs.ref-name }}
           git push origin HEAD:${{ needs.branch-context.outputs.ref-name }}
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,33 +355,26 @@ jobs:
           echo "Jira ticket: ${TICKET:-none}"
 
 
-      - name: Read current Keycloak MAJOR.MINOR from .version
+      - name: Read current Keycloak version from .version
         id: cur-version
         run: |
-          MAJOR_MINOR=$(python3 -c "
+          VERSION=$(python3 -c "
           import json
           with open('resources/.version') as f:
             data = json.load(f)
-          ver = data['application_info']['version']
-          parts = ver.split('.')
-          print('.'.join(parts[:2]))
+          print(data['application_info']['version'])
           ")
-          echo "version=$MAJOR_MINOR"         >> $GITHUB_OUTPUT
-          echo "sem-version=${MAJOR_MINOR}.0"  >> $GITHUB_OUTPUT
-          echo "Keycloak MAJOR.MINOR: $MAJOR_MINOR"
+          echo "version=$VERSION"     >> $GITHUB_OUTPUT
+          echo "sem-version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Keycloak version: $VERSION"
 
-      - name: Calculate next Keycloak patch version from git tags
+      - name: Calculate next Keycloak patch version from .version
         id: patch-version
         run: |
-          MAJOR_MINOR="${{ steps.cur-version.outputs.version }}"
-          git fetch --tags --quiet
-          LATEST=$(git tag -l "v${MAJOR_MINOR}.*" | sort -V | tail -1)
-          if [ -n "$LATEST" ]; then
-            PATCH=$(echo "$LATEST" | awk -F '.' '{ print $3 }')
-            NEXT_PATCH=$((PATCH + 1))
-          else
-            NEXT_PATCH=0
-          fi
+          CURRENT="${{ steps.cur-version.outputs.version }}"
+          MAJOR_MINOR=$(echo "$CURRENT" | awk -F '.' '{ print $1"."$2 }')
+          PATCH=$(echo "$CURRENT" | awk -F '.' '{ print $3 }')
+          NEXT_PATCH=$((PATCH + 1))
           echo "version=${MAJOR_MINOR}.${NEXT_PATCH}" >> $GITHUB_OUTPUT
           echo "Next Keycloak version: ${MAJOR_MINOR}.${NEXT_PATCH}"
 
@@ -634,7 +627,8 @@ jobs:
       needs.branch-context.outputs.should-build == 'true' &&
       needs.branch-context.outputs.is-test-run == 'false' &&
       needs.gate.result == 'success' &&
-      needs.build.result == 'success'
+      needs.build.result == 'success' &&
+      github.event_name != 'push'
     runs-on: ubuntu-latest
     env:
       HANOI_TARGET: ${{ needs.branch-context.outputs.hanoi-target }}
@@ -782,10 +776,10 @@ jobs:
         run: |
           git config user.name "vunet-new-ci-cd-bot[bot]"
           git config user.email "vunet-new-ci-cd-bot@users.noreply.github.com"
-          git add pom.xml resources/.version
+          git pull --rebase origin ${{ needs.branch-context.outputs.ref-name }}
+          git add -A
           git diff --cached --quiet || {
             git commit -m "chore: bump washington version to v${{ needs.versioning.outputs.platform-version }} [skip ci]"
-            git pull --rebase origin ${{ needs.branch-context.outputs.ref-name }}
             git push origin HEAD:${{ needs.branch-context.outputs.ref-name }}
           }
 
@@ -801,7 +795,7 @@ jobs:
       needs.branch-context.outputs.is-test-run == 'false' &&
       needs.gate.result == 'success' &&
       needs.build.result == 'success' &&
-      needs.helm-update.result == 'success'
+      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -776,12 +776,14 @@ jobs:
         run: |
           git config user.name "vunet-new-ci-cd-bot[bot]"
           git config user.email "vunet-new-ci-cd-bot@users.noreply.github.com"
-          git pull --rebase origin ${{ needs.branch-context.outputs.ref-name }}
           git add -A
-          git diff --cached --quiet || {
-            git commit -m "chore: bump washington version to v${{ needs.versioning.outputs.platform-version }} [skip ci]"
-            git push origin HEAD:${{ needs.branch-context.outputs.ref-name }}
-          }
+          if git diff --cached --quiet; then
+            echo "No changes detected, skipping commit/push."
+            exit 0
+          fi
+          git commit -m "chore: bump washington version to v${{ needs.versioning.outputs.platform-version }} [skip ci]"
+          git pull --rebase origin ${{ needs.branch-context.outputs.ref-name }}
+          git push origin HEAD:${{ needs.branch-context.outputs.ref-name }}
 
   # ---------------------------------------------------------------------------
   # 8. RELEASE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -716,7 +716,7 @@ jobs:
       needs.branch-context.outputs.branch-type == 'release' &&
       needs.versioning.outputs.keycloak-version != '' &&
       needs.build.result == 'success' &&
-      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped')
+      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped') &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -716,7 +716,7 @@ jobs:
       needs.branch-context.outputs.branch-type == 'release' &&
       needs.versioning.outputs.keycloak-version != '' &&
       needs.build.result == 'success' &&
-      needs.helm-update.result == 'success' &&
+      (needs.helm-update.result == 'success' || needs.helm-update.result == 'skipped')
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description of Changes
- Keycloak version calculation simplified to read full version directly from resources/.version (application_info.version) file.

- Commit-bumps checkout changed from checkout-ref (commit SHA) to ref-name (branch name) to ensure working with the latest branch state after release-retag completes.

- Added git pull step in commit-bumps before modifications to pull latest changes from the release branch, preventing   conflicts when release-retag has already pushed ahead.


## Linked Issues
- [CCBD-4198](https://vunetsystems.atlassian.net/browse/CCBD-4198)
  (List all related JIRA issues here.)

## Design Document

## Requirements Document


## Impact Analysis


## Any Similar Instances Found


## Root Cause Analysis 


## Files Changed
.github/workflows/release.yml:

## Tests Conducted


## Migration Steps (if applicable)


## Additional Context


## Checklist



[CCBD-4198]: https://vunetsystems.atlassian.net/browse/CCBD-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ