### PR TITLE
ci(washington - release/3.1): Prevent posthook override by using anchor-specific image updates 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -719,12 +719,15 @@ jobs:
             [ -n "$MAPPED_SUFFIX" ] && IMAGE_NAME="${{ github.repository_owner }}/${MAPPED_SUFFIX}"
           fi
 
+        
           for chart in $CHART_PATHS; do
-            [ -f "$chart/values.yaml" ] && \
-              sed -i "s|imageTag:.*|imageTag: $TAG|" "$chart/values.yaml" && \
-              sed -i "s|imageName:.*|imageName: $IMAGE_NAME|" "$chart/values.yaml"
+            if [ -f "$chart/values.yaml" ]; then
+              sed -i -E "s|(imageTag: &imageTag) .*|\1 $TAG|" "$chart/values.yaml"
+              sed -i -E "s|(imageName: &imageName) .*|\1 $IMAGE_NAME|" "$chart/values.yaml"
+            fi
           done
-
+          
+          
           git diff --quiet || {
             git add .
             git commit -m "chore: update keycloak image tag to $TAG"


### PR DESCRIPTION
## Description of Changes
- Fix CI to update only anchored imageName and imageTag in Keycloak Helm chart in Hanoi repo instead of unscoped replacements.
- Prevents YAML anchor removal and avoids overwriting posthook image.
- This PR targets the release/3.1 branch.

## Linked Issues
N/A

## Impact Analysis
- Fixes incorrect image override in posthook
- Ensures anchors are preserved
- Limits changes only to vunet image config

## Files Changed
- .github/workflows/release.yml

## Tests Conducted


## Checklist
