### PR TITLE
CCBD-4103: merge feature branch with develop

### DIFF
--- a/quarkus/container/vunet/scripts/policy/evaluate-privileges.js
+++ b/quarkus/container/vunet/scripts/policy/evaluate-privileges.js
@@ -6,6 +6,8 @@ var HashSet = java.util.HashSet;
 // Implicit privilege mappings: granting privilege -> array of privileges it grants
 var implicitPrivilegeMappings = {
   'alerts:read': ['dataModel:read', 'definitions:read', 'preferences:read'],
+  "apiKey:read": ["users:read", "serviceAccount:read"],
+  "apiKey:write": ["users:read", "users:write", "users:manageBulkObjects", "serviceAccount:read", "serviceAccount:write"],
   'alerts:write': ['dataModel:read', 'definitions:read', 'preferences:read'],
   'dashboards:admin': ['dashboards:write', 'dataModel:read', 'insights:read', 'utm:read', 'dataSource:manage'],
   'dashboards:write': ['dataModel:read', 'insights:read', 'utm:read'],
@@ -24,6 +26,8 @@ var implicitPrivilegeMappings = {
   'reports:read': ['dataModel:read', 'definitions:read', 'preferences:read'],
   'reports:write': ['dataModel:read', 'definitions:read', 'preferences:read'],
   'resources:manage': ['alerts:read', 'dataModel:read', 'insights:read', 'utm:read'],
+  "serviceAccount:read": ["users:read"],
+  "serviceAccount:write": ["users:read","users:write","users:manageBulkObjects"],
   'utm:read': ['dataModel:read'],
   'utm:write': ['dataModel:read'],
   'vumodule:modifySources': ['alerts:read', 'definitions:read', 'vumodule:read', 'dataModel:read'],


### PR DESCRIPTION
## Description of Changes
Adds implicit privilege mappings so that API key and service account privileges automatically grant the underlying user-management and service-account scopes they depend on.

- **New Features**: Introduced four new entries in `implicitPrivilegeMappings` in `evaluate-privileges.js`:
  - `apiKey:read` → `users:read`, `serviceAccount:read`
  - `apiKey:write` → `users:read`, `users:write`, `users:manageBulkObjects`, `serviceAccount:read`, `serviceAccount:write`
  - `serviceAccount:read` → `users:read`
  - `serviceAccount:write` → `users:read`, `users:write`, `users:manageBulkObjects`
- **Bug Fixes**: None.
- **Refactoring**: None — additive change only, no logic modified.
- **Optimizations**: None.

## Linked Issues
- [CCBD-4103](https://vunetsystems.atlassian.net/browse/CCBD-4103): *API key and service account management*

## Design Document
[`for feature`]
[Design Document](https://docs.google.com/document/d/1TVQAcWZJxLf0Hctn1O-3VLzPayZidc7ShzJ1R3mdQo0/edit?usp=sharing)

## Requirements Document
[`for feature`]
N/A — no separate requirements document.

## Impact Analysis
The change extends the privilege-resolution engine (`_extendExplicitPrivileges`) with new keys only; no evaluation logic is altered.

- Users/groups whose `privilege` attribute includes `apiKey:*` or `serviceAccount:*` will now additionally resolve to the implied `users:*` and `serviceAccount:*` scopes, enabling API key / service account flows that call the user and service-account APIs.
- No effect on users who do not hold `apiKey` or `serviceAccount` privileges — the mappings are only applied when the granting privilege is explicitly assigned.
- `users:read` is listed explicitly alongside every `users:write`/`users:manageBulkObjects` because the automatic write→read derivation only applies to a user's *explicit* privileges, not to privileges pulled in through the mapping (expansion is single-level, non-recursive). Omitting it would leave read access ungranted.
- Change is confined to the `vsmaps-extensions.jar` script provider; requires the `scripts` feature (already enabled via `KC_FEATURES=scripts`). No DB schema or config changes.

## Files Changed
- `quarkus/container/vunet/scripts/policy/evaluate-privileges.js`: Added four implicit privilege mapping entries for `apiKey` and `serviceAccount` (read/write scopes).

## Tests Conducted

1. **Verified implied privilege grants**
   - **Description**: Confirm that a principal granted an API key / service account privilege resolves to the expected implied scopes.
   - **Steps**:
     1. Assign a group the `apiKey:write` (and separately `serviceAccount:write`) privilege attribute.
     2. Run privilege evaluation for a user in that group against the affected resources.
     3. Inspect the resolved privilege set.
   - **Expected Result**: Extended privileges include `users:read`, `users:write`, `users:manageBulkObjects`, `serviceAccount:read`, `serviceAccount:write` (per the mapping); read-only variants resolve to their read scopes only.
   - **Actual Result**: Grants resolved as expected — implied scopes present.

## Migration Steps (if applicable)
None. The updated `evaluate-privileges.js` ships inside `vsmaps-extensions.jar` and is picked up when the Keycloak image is rebuilt/redeployed. No DB migration or config change required.

## Rollback Instructions (if applicable)
Revert the commit (`git revert 7e15575`) and redeploy the Keycloak image; the four mapping entries are removed with no residual state.

## Additional Context
Expansion in `_extendExplicitPrivileges` is intentionally single-level and non-recursive — granted privileges are not themselves re-expanded — which is why each mapping enumerates every required scope (including `read`) explicitly.

## Checklist
- [ ] I have reviewed my code for errors and potential refactoring.
- [ ] I have updated the documentation as necessary.
- [ ] I have added tests to cover my changes.
- [ ] This PR is ready for review.



[CCBD-4103]: https://vunetsystems.atlassian.net/browse/CCBD-4103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ