### PR TITLE
fix(ci): build develop on push (fork PR merges had no secrets -> app-token 'appId required')

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: Build Washington Images
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - develop
-
+  # Build on PUSH to develop (i.e. after a PR merges), NOT on pull_request:closed.
+  # A pull_request event whose head is a FORK runs without repo secrets, so the
+  # "Generate GitHub App Token" step got an empty app-id and failed with
+  # "[@octokit/auth-app] appId option is required". A merge always produces a
+  # push to develop in THIS repo, which runs with full secret access regardless
+  # of whether the PR came from a fork — matching how release/** and feature/**
+  # already trigger below.
   push:
     branches:
+      - develop
       - 'release/**'
       - 'feature/**'
 
@@ -131,7 +133,7 @@ jobs:
             exit 0
           fi
 
-          if [[ "$EVENT" == "pull_request" && "$PR_MERGED" == "true" && "$BASE_REF" == "develop" ]]; then
+          if [[ "$EVENT" == "push" && "$REF" == "develop" ]]; then
             echo "branch-type=develop"                              >> $GITHUB_OUTPUT
             echo "image-tag-prefix=main-b${{ github.run_number }}" >> $GITHUB_OUTPUT
             echo "hanoi-target=develop"                            >> $GITHUB_OUTPUT
@@ -141,7 +143,7 @@ jobs:
             echo "run-release=true"                                >> $GITHUB_OUTPUT
             echo "concurrency-group=washington-develop"            >> $GITHUB_OUTPUT
             echo "ref-name=develop"                                >> $GITHUB_OUTPUT
-            echo "checkout-ref=${{ github.event.pull_request.merge_commit_sha || github.sha }}" >> $GITHUB_OUTPUT
+            echo "checkout-ref=$DEFAULT_CHECKOUT_REF"              >> $GITHUB_OUTPUT
             exit 0
           fi
 


### PR DESCRIPTION
## Cause
The failing run was a **merged PR from a fork** (`chithra-vunet/washington` -> `vunetsystems/washington`). The develop build triggered on `pull_request: [closed]`, and a `pull_request` event whose head is a fork runs **without the base repo's secrets** (GitHub never exposes secrets to fork PR runs). So `create-github-app-token@v2` got an empty `app-id` (`secrets.VUNET_NEW_CICD_APP_ID`) and failed:
```
Error: [@octokit/auth-app] appId option is required
```
It is **not** the fork's configuration — the base build simply wasn't handed the secrets.

## Fix
Trigger the develop build on **`push: develop`** instead of `pull_request: closed`. Merging any PR (fork or not) produces a push to `develop` in this repo, which runs with full secret access — exactly how `release/**` and `feature/**` already trigger. `branch-context` now detects `push` + `ref == develop`; downstream gates key off its outputs (unchanged: `run-release=true`, `run-versioning=false`), so behavior is identical minus the fork-secret problem.

Answers to the thread:
1. The base build doesn't depend on fork config — GitHub withholds secrets from fork-PR-triggered runs by design; switching to `push` removes any fork context.
2. It ran post-merge because the trigger was `pull_request: closed`; a pre-merge check couldn't have caught it (same missing-secret condition). `push`-on-merge is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)